### PR TITLE
Process definitions instead of process model

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/bootstrapper_contracts": "^1.0.0",
     "@essential-projects/errors_ts": "^1.1.0",
     "@essential-projects/http_node": "^3.0.2",
-    "@process-engine/deployment_api_contracts": "^0.1.0",
+    "@process-engine/deployment_api_contracts": "feature~process_definitions_instead_of_process_model",
     "async-middleware": "^1.2.1"
   },
   "devDependencies": {

--- a/src/endpoints/import/import_controller.ts
+++ b/src/endpoints/import/import_controller.ts
@@ -2,7 +2,7 @@ import {
   DeploymentContext,
   DeploymentRequest,
   IDeploymentApiService,
-  ImportProcessModelRequestPayload,
+  ImportProcessDefinitionsRequestPayload,
 } from '@process-engine/deployment_api_contracts';
 
 import {Response} from 'express';
@@ -24,7 +24,7 @@ export class ImportController {
 
   public async importProcessModel(request: DeploymentRequest, response: Response): Promise<void> {
     const context: DeploymentContext = request.deploymentContext;
-    const payload: ImportProcessModelRequestPayload = request.body;
+    const payload: ImportProcessDefinitionsRequestPayload = request.body;
 
     const result: any = await this.deploymentApiService.importBpmnFromXml(context, payload);
 


### PR DESCRIPTION
Depends on:
* https://github.com/process-engine/deployment_api_contracts/pull/3

## What did you change?

* renamed `ImportProcessModelRequestPayload` to `ImportProcessDefinitionsRequestPayload` to reflect the change of entity

## How can others test the changes?

All integration tests in meta repositories should run successfully: 

* https://github.com/process-engine/management_api_meta/pull/6
* https://github.com/process-engine/consumer_api_meta/pull/40
* https://github.com/process-engine/deployment_api_meta/pull/3
* https://github.com/process-engine/process_engine_meta/pull/122

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
